### PR TITLE
Add offline installation scripts

### DIFF
--- a/scripts/install_offline.sh
+++ b/scripts/install_offline.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Install tffsmount and its dependencies from an offline bundle.
+# Run this on an air-gapped Ubuntu 24.04.3 system after copying the bundle
+# produced by prepare_offline.sh.
+
+set -euo pipefail
+
+BUNDLE_DIR=${1:-tffsmount_offline}
+
+# Install Debian packages
+sudo apt-get install -y --no-download "$BUNDLE_DIR"/deb/*.deb
+
+# Create and activate virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# Install Python dependencies and tffsmount from the local wheel cache
+pip install --no-index --find-links="$BUNDLE_DIR/pip" \
+    fusepy kaitaistruct crcengine tffsmount
+
+deactivate
+
+echo "tffsmount installed. Activate the virtual environment with 'source venv/bin/activate'."
+

--- a/scripts/prepare_offline.sh
+++ b/scripts/prepare_offline.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Prepare offline installation bundle for tffsmount.
+# This script must be run on an internet-connected Ubuntu 24.04.3 machine.
+# It downloads required Debian packages and Python wheels so tffsmount can be
+# installed without any network access.
+
+set -euo pipefail
+
+BUNDLE_DIR=${1:-tffsmount_offline}
+
+# Create directory layout
+mkdir -p "$BUNDLE_DIR/pip" "$BUNDLE_DIR/deb"
+
+# Build wheel for tffsmount itself
+python3 -m pip wheel . -w "$BUNDLE_DIR/pip"
+
+# Download pip dependencies
+python3 -m pip download \
+  --dest "$BUNDLE_DIR/pip" \
+  fusepy==3.0.1 \
+  kaitaistruct==0.10 \
+  crcengine==0.3
+
+# Download apt packages (and their dependencies)
+APT_PACKAGES=(fuse python3 python3-venv python3-pip)
+
+sudo apt-get update
+# Store downloaded debs in our bundle directory
+sudo apt-get install --reinstall --download-only -y "${APT_PACKAGES[@]}" \
+  -o Dir::Cache="$(pwd)/$BUNDLE_DIR/apt-cache" \
+  -o Dir::Cache::archives="$(pwd)/$BUNDLE_DIR/deb"
+
+# Remove temporary apt cache directory
+rm -rf "$BUNDLE_DIR/apt-cache"
+
+echo "Offline bundle created in $BUNDLE_DIR"
+echo "Copy the entire $BUNDLE_DIR directory to a USB drive."
+read -rp "Press Enter after safely removing the USB to finish." _
+


### PR DESCRIPTION
## Summary
- Add `prepare_offline.sh` to bundle Debian and pip packages for tffsmount on an online machine
- Add `install_offline.sh` to install those packages and tffsmount on an air‑gapped machine

## Testing
- `pytest`
- `shellcheck scripts/prepare_offline.sh scripts/install_offline.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e0d7a42f4832da23b39fd715f3ff3