### PR TITLE
Improve offline installer

### DIFF
--- a/scripts/install_offline.sh
+++ b/scripts/install_offline.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 BUNDLE_DIR=${1:-tffsmount_offline}
 
 # Install Debian packages
-sudo apt-get install -y --no-download "$BUNDLE_DIR"/deb/*.deb
+sudo dpkg -i "$BUNDLE_DIR"/deb/*.deb && sudo apt-get -y --no-download -f install
 
 # Create and activate virtual environment
 python3 -m venv venv


### PR DESCRIPTION
## Summary
- Ensure offline installer resolves package dependencies locally using `dpkg` then `apt-get` with `--no-download`

## Testing
- `pytest -q`
- `./scripts/prepare_offline.sh tffsmount_offline_test`
- `http_proxy=http://127.0.0.1:9 https_proxy=http://127.0.0.1:9 ./scripts/install_offline.sh tffsmount_offline_test`


------
https://chatgpt.com/codex/tasks/task_e_689e1b45e890832d9e176f4fdc47fbdf